### PR TITLE
Add integration tests for keypress

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -1,0 +1,74 @@
+// Karma configuration
+// Generated on Tue Jun 06 2017 19:34:40 GMT-0600 (MDT)
+
+module.exports = function(config) {
+  config.set({
+
+    // base path that will be used to resolve all patterns (eg. files, exclude)
+    basePath: '',
+
+
+    // frameworks to use
+    // available frameworks: https://npmjs.org/browse/keyword/karma-adapter
+    frameworks: ['mocha', 'browserify'],
+
+
+    // list of files / patterns to load in the browser
+    files: [
+      'test/**/*_spec.js'
+    ],
+
+
+    // list of files to exclude
+    exclude: [
+    ],
+
+
+    // preprocess matching files before serving them to the browser
+    // available preprocessors: https://npmjs.org/browse/keyword/karma-preprocessor
+    preprocessors: {
+      'test/**/*_spec.js': [ 'browserify' ]
+    },
+
+    browserify: {
+      debug: true
+    },
+
+
+    // test results reporter to use
+    // possible values: 'dots', 'progress'
+    // available reporters: https://npmjs.org/browse/keyword/karma-reporter
+    reporters: ['progress'],
+
+
+    // web server port
+    port: 9876,
+
+
+    // enable / disable colors in the output (reporters and logs)
+    colors: true,
+
+
+    // level of logging
+    // possible values: config.LOG_DISABLE || config.LOG_ERROR || config.LOG_WARN || config.LOG_INFO || config.LOG_DEBUG
+    logLevel: config.LOG_INFO,
+
+
+    // enable / disable watching file and executing tests whenever any file changes
+    autoWatch: true,
+
+
+    // start these browsers
+    // available browser launchers: https://npmjs.org/browse/keyword/karma-launcher
+    browsers: ['Chrome'],
+
+
+    // Continuous Integration mode
+    // if true, Karma captures browsers, runs the tests and exits
+    singleRun: false,
+
+    // Concurrency level
+    // how many browser should be started simultaneous
+    concurrency: Infinity
+  })
+}

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "front end module for arcade controls",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "karma start --single-run"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -22,5 +22,15 @@
   "homepage": "https://github.com/bthesorceror/arcade_keys",
   "dependencies": {
     "frontdesk": "git://github.com/bthesorceror/frontdesk"
+  },
+  "devDependencies": {
+    "browserify": "^14.4.0",
+    "expect": "^1.20.2",
+    "karma": "^1.7.0",
+    "karma-browserify": "^5.1.1",
+    "karma-chrome-launcher": "^2.1.1",
+    "karma-mocha": "^1.3.0",
+    "mocha": "^3.4.2",
+    "watchify": "^3.9.0"
   }
 }

--- a/test/integration/index_spec.js
+++ b/test/integration/index_spec.js
@@ -1,0 +1,29 @@
+var ArcadeKeys = require('../../index')
+var expect = require('expect')
+
+describe('key press is stored', function () {
+  it('returns that the key is not pressed', function () {
+    var ak = ArcadeKeys()
+    expect(ak.isPressed(ArcadeKeys.keys.up)).toBe(false)
+  })
+
+  it('retuns that the key is pressed', function () {
+    var ak = ArcadeKeys()
+    simulateKeyPress('keydown')
+    expect(ak.isPressed(ArcadeKeys.keys.up)).toBe(true)
+    simulateKeyPress('keyup')
+    expect(ak.isPressed(ArcadeKeys.keys.up)).toBe(false)
+  })
+})
+
+function simulateKeyPress (eventType) {
+  var e = new window.Event(eventType)
+  e.keyCode = ArcadeKeys.keys.up
+  e.which = e.keyCode
+  e.altKey = false
+  e.ctrlKey = false
+  e.shiftKey = false
+  e.metaKey = false
+  e.bubbles = true
+  document.dispatchEvent(e)
+}


### PR DESCRIPTION
Since I encountered a slight bug when I used this module (which I think you already fixed), I thought tests could help keep track of performance. I used karma and karma-browserify to write integration tests to check for key presses. 

Triggering the keypress in the test was tough--I found some ways to do it with jquery, but I didn't want to bring in the whole library just for the test. Eventually, I found a method that works without it.

Let me know what you think!